### PR TITLE
Bug Fix

### DIFF
--- a/aws-waf-classic/operations.py
+++ b/aws-waf-classic/operations.py
@@ -110,7 +110,7 @@ def _boto_execute(client, function, **kwargs):
 
 def check_health(config):
     try:
-        available = _create_client(config)
+        available = list_ip_set(config, {})
         if available:
             return True
         else:


### PR DESCRIPTION
#### Descriptions:

The health check was available with invalid values of the Access Key and Secret key.

#### Fix:

Resolved by calling an action during the check health.

UTC:

Verified the above change in the FortiSOAR UI.

